### PR TITLE
Add ::after to NanoService::Base

### DIFF
--- a/lib/nano-service/base.rb
+++ b/lib/nano-service/base.rb
@@ -96,9 +96,6 @@ module NanoService
         method_names.map!(&:to_sym)
         method_names << ANY_METHOD if method_names.empty?
         method_names.each do |method_name|
-          unless instance_methods.include?(method_name) || method_name == ANY_METHOD
-            raise ArgumentError, "unable to register callback for missing method: #{method_name}"
-          end
           (after_callbacks[method_name] ||= []) << block
         end
 

--- a/lib/nano-service/base.rb
+++ b/lib/nano-service/base.rb
@@ -2,6 +2,9 @@ module NanoService
   module Base
     extend ActiveSupport::Concern
 
+    ANY_METHOD = Object.new
+    private_constant :ANY_METHOD
+
     # dynamically define NanoService exceptions on the including Service module
     included do
       @namespace = Kernel.const_get(name.split('::')[0])
@@ -21,6 +24,11 @@ module NanoService
         if instance_methods.include?(method_name)
           begin
             res = caller_object.send(method_name, *args)
+
+            [method_name, ANY_METHOD].each do |name|
+              after_callbacks.fetch(name, []).each { |c| c.call(method_name, *args) }
+            end
+
             if res.is_a?(Hash)
               res.with_indifferent_access
             elsif res.is_a?(Array)
@@ -34,6 +42,10 @@ module NanoService
         else
           super
         end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        instance_methods.include?(method_name) || super
       end
 
       def handle_exception(e)
@@ -80,7 +92,24 @@ module NanoService
         @test_interface
       end
 
+      def after(*method_names, &block)
+        method_names.map!(&:to_sym)
+        method_names << ANY_METHOD if method_names.empty?
+        method_names.each do |method_name|
+          unless instance_methods.include?(method_name) || method_name == ANY_METHOD
+            raise ArgumentError, "unable to register callback for missing method: #{method_name}"
+          end
+          (after_callbacks[method_name] ||= []) << block
+        end
+
+        nil
+      end
+
       private
+
+      def after_callbacks
+        @after_callbacks ||= { ANY_METHOD => [] }
+      end
 
       def register_test_interface(klass)
         @test_interface = klass

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -25,13 +25,6 @@ describe NanoService::Base do
   end
 
   describe '::after' do
-    it 'raises if specified service method is missing' do
-      expect {
-        callback = proc {}
-        MyService.after :echo, :bogus_method, &callback
-      }.to raise_error(/unable to register callback for missing method: bogus_method/)
-    end
-
     it 'registers a proc to be called after the specified service method is invoked' do
       expect do |block|
         MyService.after :echo, :return_a_hash, &block

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -24,6 +24,40 @@ describe NanoService::Base do
     end
   end
 
+  describe '::after' do
+    it 'raises if specified service method is missing' do
+      expect {
+        callback = proc {}
+        MyService.after :echo, :bogus_method, &callback
+      }.to raise_error(/unable to register callback for missing method: bogus_method/)
+    end
+
+    it 'registers a proc to be called after the specified service method is invoked' do
+      expect do |block|
+        MyService.after :echo, :return_a_hash, &block
+        2.times { MyService.echo(message: 'hi') }
+        MyService.return_a_hash
+      end.to yield_successive_args(
+        [:echo, message: 'hi'],
+        [:echo, message: 'hi'],
+        :return_a_hash
+      )
+    end
+
+    it 'registers a proc to be called after any service method is invoked' do
+      expect do |block|
+        MyService.after &block
+        MyService.echo(message: 'hi')
+        MyService.return_a_hash
+        MyService.return_an_array_of_hashes
+      end.to yield_successive_args(
+        [:echo, message: 'hi'],
+        :return_a_hash,
+        :return_an_array_of_hashes
+      )
+    end
+  end
+
   describe 'test mode' do
     after { MyService.test_mode = false }
 

--- a/spec/support/my_service.rb
+++ b/spec/support/my_service.rb
@@ -4,6 +4,10 @@ module MyService
   include NanoService::Base
   register_test_interface MyServiceMock
 
+  def echo(**kwargs)
+    kwargs
+  end
+
   def return_a_hash
     { foo: 'bar' }
   end

--- a/spec/support/my_service_mock.rb
+++ b/spec/support/my_service_mock.rb
@@ -1,4 +1,8 @@
 module MyServiceMock
+  def echo(**kwargs)
+    kwargs
+  end
+
   def return_a_hash
     {}
   end


### PR DESCRIPTION
## What this PR does

Allows modules that include `NanoService::Base` to specify procs to be called after specific (or any) service methods are invoked.

Example:

```ruby
module MyService
  include NanoService::Base

  after do |method_name, *args|
    puts "#{method_name} was called with #{args}"
  end

  after :foo, :bar do |method_name, *args|
    puts "#{method_name} was called with #{args}"
  end

  def foo; end
  def bar; end
  def baz; end
end
```