### PR TITLE
Security updates: Bump globalid and activerecord

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,12 +9,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.5.1)
-      activesupport (= 6.0.5.1)
-    activerecord (6.0.5.1)
-      activemodel (= 6.0.5.1)
-      activesupport (= 6.0.5.1)
-    activesupport (6.0.5.1)
+    activemodel (6.0.6.1)
+      activesupport (= 6.0.6.1)
+    activerecord (6.0.6.1)
+      activemodel (= 6.0.6.1)
+      activesupport (= 6.0.6.1)
+    activesupport (6.0.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     nano-service (0.2.1)
       activerecord (>= 6.0.4, < 7.1.0)
       activesupport (~> 6.0.4)
-      globalid (= 0.4.2)
+      globalid (~> 1.0, >= 1.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -22,11 +22,11 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
+    globalid (1.0.1)
+      activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.16.2)
+    minitest (5.17.0)
     rake (13.0.6)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -44,7 +44,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/nano-service.gemspec
+++ b/nano-service.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord',  '>= 6.0.4', '< 7.1.0'
   s.add_dependency 'activesupport', '~> 6.0.4'
-  s.add_dependency 'globalid',      '0.4.2'
+  s.add_dependency 'globalid',      '~> 1.0', '>= 1.0.1'
 end


### PR DESCRIPTION
The current versions of both these gems include low-risk security vulnerabilities. This PR bumps them.

In addition, now that globalid has reached a stable API, it no longer pins the gem to a specific version. This will make it so that we can upgrade globalid to newer minor or patch versions in other repos (e.g., portal), and the version constraints in this repo preventing us from doing so.

Upgrading portal's globalid gem is the impetus for this PR.