### PR TITLE
Bump dep versions to support rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ ruby IO.read(File.expand_path('../.ruby-version', __FILE__)).chomp
 gemspec
 
 group :development, :test do
-  gem 'rake',  '13.0.6'
-  gem 'rspec', '3.6.0'
+  gem 'rake',  '~> 13.0.6'
+  gem 'rspec', '~> 3.12.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,19 +27,19 @@ GEM
       concurrent-ruby (~> 1.0)
     minitest (5.17.0)
     rake (13.0.6)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
@@ -48,8 +48,8 @@ PLATFORMS
 
 DEPENDENCIES
   nano-service!
-  rake (= 13.0.6)
-  rspec (= 3.6.0)
+  rake (~> 13.0.6)
+  rspec (~> 3.12.0)
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,24 +2,23 @@ PATH
   remote: .
   specs:
     nano-service (0.3.0)
-      activerecord (>= 6.0.4, < 7.1.0)
-      activesupport (>= 6.0.4, < 7)
-      globalid (~> 1.0, >= 1.0.1)
+      activerecord (>= 6, < 8)
+      activesupport (>= 6, < 8)
+      globalid (>= 1.0.1, < 1.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.7.1)
-      activesupport (= 6.1.7.1)
-    activerecord (6.1.7.1)
-      activemodel (= 6.1.7.1)
-      activesupport (= 6.1.7.1)
-    activesupport (6.1.7.1)
+    activemodel (7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activerecord (7.0.4.2)
+      activemodel (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     concurrent-ruby (1.2.0)
     diff-lcs (1.5.0)
     globalid (1.0.1)
@@ -41,12 +40,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.6)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   nano-service!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
-  arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   nano-service!

--- a/nano-service.gemspec
+++ b/nano-service.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = ">= #{IO.read(File.expand_path('.ruby-version', __dir__)).chomp}"
 
-  s.add_dependency 'activerecord',  '>= 6.0.4', '< 7.1.0'
-  s.add_dependency 'activesupport', '>= 6.0.4', '< 7'
-  s.add_dependency 'globalid',      '~> 1.0', '>= 1.0.1'
+  s.add_dependency 'activerecord',  '>= 6', '< 8'
+  s.add_dependency 'activesupport', '>= 6', '< 8'
+  s.add_dependency 'globalid',      '>= 1.0.1', '< 1.1.0'
 end


### PR DESCRIPTION
The title says it all. No changes needed to support Rails 7.
